### PR TITLE
 Event poster upload with image compression and UI polish

### DIFF
--- a/app/src/main/java/com/example/eventlotteryapp/repository/ImageRepository.java
+++ b/app/src/main/java/com/example/eventlotteryapp/repository/ImageRepository.java
@@ -1,0 +1,102 @@
+package com.example.eventlotteryapp.repository;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.net.Uri;
+
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+public class ImageRepository {
+
+    private static final int MAX_DIMENSION = 1024; // px
+    private static final int JPEG_QUALITY  = 80;   // %
+
+    private final FirebaseStorage storage;
+
+    public ImageRepository() {
+        storage = FirebaseStorage.getInstance();
+    }
+
+    public interface UploadCallback {
+        void onSuccess(String downloadUrl);
+        void onFailure(Exception e);
+    }
+
+    /**
+     * Compresses the image from the given Uri, then uploads it to Firebase Storage.
+     * Scales down to MAX_DIMENSION on the longest side and compresses to JPEG at JPEG_QUALITY.
+     * Path: event_posters/{deviceId}_{timestamp}.jpg
+     */
+    public void uploadEventPoster(Context context, String deviceId, Uri imageUri,
+                                  UploadCallback callback) {
+        byte[] compressed = compressImage(context, imageUri);
+        if (compressed == null) {
+            callback.onFailure(new Exception("Failed to process image"));
+            return;
+        }
+
+        String fileName = "event_posters/" + deviceId + "_" + System.currentTimeMillis() + ".jpg";
+        StorageReference ref = storage.getReference().child(fileName);
+
+        ref.putBytes(compressed)
+                .continueWithTask(task -> {
+                    if (!task.isSuccessful() && task.getException() != null) {
+                        throw task.getException();
+                    }
+                    return ref.getDownloadUrl();
+                })
+                .addOnSuccessListener(uri -> callback.onSuccess(uri.toString()))
+                .addOnFailureListener(callback::onFailure);
+    }
+
+    /**
+     * Reads the image from Uri, scales it down if needed, and compresses to JPEG bytes.
+     * Returns null if anything goes wrong.
+     */
+    private byte[] compressImage(Context context, Uri uri) {
+        try {
+            // Decode bitmap from Uri using InputStream (BitmapFactory.decodeStream
+            // is the correct non-deprecated approach for all API levels)
+            InputStream stream = context.getContentResolver().openInputStream(uri);
+            Bitmap original = BitmapFactory.decodeStream(stream);
+            if (stream != null) stream.close();
+            if (original == null) return null;
+
+            // Scale down if either dimension exceeds MAX_DIMENSION
+            Bitmap scaled = scaleBitmap(original);
+
+            // Compress to JPEG bytes
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            scaled.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, out);
+
+            // Free memory
+            if (scaled != original) scaled.recycle();
+            original.recycle();
+
+            return out.toByteArray();
+
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Bitmap scaleBitmap(Bitmap bitmap) {
+        int width  = bitmap.getWidth();
+        int height = bitmap.getHeight();
+
+        if (width <= MAX_DIMENSION && height <= MAX_DIMENSION) {
+            return bitmap; // already small enough, no scaling needed
+        }
+
+        float scale = (float) MAX_DIMENSION / Math.max(width, height);
+        int newWidth  = Math.round(width  * scale);
+        int newHeight = Math.round(height * scale);
+
+        return Bitmap.createScaledBitmap(bitmap, newWidth, newHeight, true);
+    }
+}

--- a/app/src/main/java/com/example/eventlotteryapp/ui/fragments/CreateEventFragment.java
+++ b/app/src/main/java/com/example/eventlotteryapp/ui/fragments/CreateEventFragment.java
@@ -1,5 +1,6 @@
 package com.example.eventlotteryapp.ui.fragments;
 
+import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -8,36 +9,50 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.ImageView;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
+import com.bumptech.glide.Glide;
 import com.example.eventlotteryapp.R;
 import com.example.eventlotteryapp.models.Event;
 import com.example.eventlotteryapp.models.User;
 import com.example.eventlotteryapp.repository.EventRepository;
+import com.example.eventlotteryapp.repository.ImageRepository;
 import com.example.eventlotteryapp.repository.UserRepository;
 
 import java.util.Date;
 
 public class CreateEventFragment extends Fragment {
 
-    private EditText titleInput;
-    private EditText descriptionInput;
-    private EditText waitlistLimitInput;
-    private CheckBox hasWaitlistLimitCheckBox;
-    private CheckBox geolocationRequiredCheckBox;
+    private ImageView posterImageView;
+    private EditText titleInput, descriptionInput, waitlistLimitInput;
+    private CheckBox hasWaitlistLimitCheckBox, geolocationRequiredCheckBox;
     private Button createButton;
 
     private EventRepository eventRepository;
     private UserRepository userRepository;
-    private String deviceId;
+    private ImageRepository imageRepository;
 
-    public CreateEventFragment() {
-        // required empty public constructor
-    }
+    private String deviceId;
+    private Uri selectedImageUri = null; // null means no image selected
+
+    // Registers the gallery picker — must be set up before onCreateView
+    private final ActivityResultLauncher<String> galleryLauncher =
+            registerForActivityResult(new ActivityResultContracts.GetContent(), uri -> {
+                if (uri != null) {
+                    selectedImageUri = uri;
+                    // Show the selected image immediately in the preview
+                    Glide.with(this).load(uri).centerCrop().into(posterImageView);
+                }
+            });
+
+    public CreateEventFragment() {}
 
     @Nullable
     @Override
@@ -47,31 +62,35 @@ public class CreateEventFragment extends Fragment {
 
         View view = inflater.inflate(R.layout.fragment_create_event, container, false);
 
-        titleInput = view.findViewById(R.id.edit_event_title);
-        descriptionInput = view.findViewById(R.id.edit_event_description);
-        waitlistLimitInput = view.findViewById(R.id.edit_waitlist_limit);
-        hasWaitlistLimitCheckBox = view.findViewById(R.id.checkbox_has_waitlist_limit);
+        posterImageView       = view.findViewById(R.id.image_event_poster);
+        Button uploadButton   = view.findViewById(R.id.button_upload_poster);
+        titleInput            = view.findViewById(R.id.edit_event_title);
+        descriptionInput      = view.findViewById(R.id.edit_event_description);
+        waitlistLimitInput    = view.findViewById(R.id.edit_waitlist_limit);
+        hasWaitlistLimitCheckBox    = view.findViewById(R.id.checkbox_has_waitlist_limit);
         geolocationRequiredCheckBox = view.findViewById(R.id.checkbox_geolocation_required);
-        createButton = view.findViewById(R.id.button_create_event);
+        createButton          = view.findViewById(R.id.button_create_event);
 
         if (getArguments() != null) {
             deviceId = getArguments().getString("deviceId");
         }
 
         eventRepository = new EventRepository();
-        userRepository = new UserRepository();
+        userRepository  = new UserRepository();
+        imageRepository = new ImageRepository();
 
+        uploadButton.setOnClickListener(v -> galleryLauncher.launch("image/*"));
         createButton.setOnClickListener(v -> saveEventToFirestore());
 
         return view;
     }
 
     private void saveEventToFirestore() {
-        String title = titleInput.getText().toString().trim();
+        String title       = titleInput.getText().toString().trim();
         String description = descriptionInput.getText().toString().trim();
         String waitlistText = waitlistLimitInput.getText().toString().trim();
 
-        boolean hasWaitlistLimit = hasWaitlistLimitCheckBox.isChecked();
+        boolean hasWaitlistLimit    = hasWaitlistLimitCheckBox.isChecked();
         boolean geolocationRequired = geolocationRequiredCheckBox.isChecked();
 
         if (TextUtils.isEmpty(title)) {
@@ -102,53 +121,90 @@ public class CreateEventFragment extends Fragment {
 
         final int finalWaitlistLimit = waitlistLimit;
 
-        // Fetch organizer name first so we can store it on the event
+        // Step 1: fetch organizer name
         userRepository.getUser(deviceId, new UserRepository.FirestoreCallback<User>() {
             @Override
             public void onSuccess(User user) {
                 String organizerName = (user != null && user.getName() != null)
-                        ? user.getName()
-                        : "Unknown";
+                        ? user.getName() : "Unknown";
 
-                Event event = new Event();
-                event.setTitle(title);
-                event.setDescription(description);
-                event.setOrganizerId(deviceId);
-                event.setOrganizerName(organizerName);
-                event.setPosterUrl("");
-                event.setQrCodeValue("");
-                event.setRegistrationOpenDate(new Date());
-                event.setRegistrationCloseDate(new Date());
-                event.setGeolocationRequired(geolocationRequired);
-                event.setHasWaitlistLimit(hasWaitlistLimit);
-                event.setWaitlistLimit(finalWaitlistLimit);
+                if (selectedImageUri != null) {
+                    // Step 2a: upload poster first, then save event with URL
+                    uploadPosterThenSave(organizerName, finalWaitlistLimit,
+                            hasWaitlistLimit, geolocationRequired, title, description);
+                } else {
+                    // Step 2b: no image — save event immediately with empty posterUrl
+                    buildAndSaveEvent(organizerName, "", title, description,
+                            finalWaitlistLimit, hasWaitlistLimit, geolocationRequired);
+                }
+            }
 
-                eventRepository.addEvent(event, new EventRepository.FirestoreCallback<String>() {
-                    @Override
-                    public void onSuccess(String result) {
-                        if (getContext() != null) {
-                            Toast.makeText(getContext(), "Event created!", Toast.LENGTH_SHORT).show();
-                        }
-                        clearForm();
-                        if (getParentFragmentManager().getBackStackEntryCount() > 0) {
-                            getParentFragmentManager().popBackStack();
-                        }
-                    }
+            @Override
+            public void onFailure(Exception e) {
+                Toast.makeText(getContext(), "Failed to load your profile", Toast.LENGTH_SHORT).show();
+                createButton.setEnabled(true);
+            }
+        });
+    }
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        if (getContext() != null) {
-                            Toast.makeText(getContext(), "Failed to save event", Toast.LENGTH_SHORT).show();
-                        }
-                        createButton.setEnabled(true);
-                    }
-                });
+    private void uploadPosterThenSave(String organizerName, int waitlistLimit,
+                                      boolean hasWaitlistLimit, boolean geolocationRequired,
+                                      String title, String description) {
+        Toast.makeText(getContext(), "Uploading poster...", Toast.LENGTH_SHORT).show();
+
+        imageRepository.uploadEventPoster(requireContext(), deviceId, selectedImageUri, new ImageRepository.UploadCallback() {
+            @Override
+            public void onSuccess(String downloadUrl) {
+                buildAndSaveEvent(organizerName, downloadUrl, title, description,
+                        waitlistLimit, hasWaitlistLimit, geolocationRequired);
             }
 
             @Override
             public void onFailure(Exception e) {
                 if (getContext() != null) {
-                    Toast.makeText(getContext(), "Failed to load your profile", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(getContext(), "Poster upload failed — saving event without image",
+                            Toast.LENGTH_SHORT).show();
+                }
+                // Still save the event, just without a poster
+                buildAndSaveEvent(organizerName, "", title, description,
+                        waitlistLimit, hasWaitlistLimit, geolocationRequired);
+            }
+        });
+    }
+
+    private void buildAndSaveEvent(String organizerName, String posterUrl,
+                                   String title, String description,
+                                   int waitlistLimit, boolean hasWaitlistLimit,
+                                   boolean geolocationRequired) {
+        Event event = new Event();
+        event.setTitle(title);
+        event.setDescription(description);
+        event.setOrganizerId(deviceId);
+        event.setOrganizerName(organizerName);
+        event.setPosterUrl(posterUrl);
+        event.setQrCodeValue("");
+        event.setRegistrationOpenDate(new Date());
+        event.setRegistrationCloseDate(new Date());
+        event.setGeolocationRequired(geolocationRequired);
+        event.setHasWaitlistLimit(hasWaitlistLimit);
+        event.setWaitlistLimit(waitlistLimit);
+
+        eventRepository.addEvent(event, new EventRepository.FirestoreCallback<String>() {
+            @Override
+            public void onSuccess(String result) {
+                if (getContext() != null) {
+                    Toast.makeText(getContext(), "Event created!", Toast.LENGTH_SHORT).show();
+                }
+                clearForm();
+                if (getParentFragmentManager().getBackStackEntryCount() > 0) {
+                    getParentFragmentManager().popBackStack();
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (getContext() != null) {
+                    Toast.makeText(getContext(), "Failed to save event", Toast.LENGTH_SHORT).show();
                 }
                 createButton.setEnabled(true);
             }
@@ -161,5 +217,9 @@ public class CreateEventFragment extends Fragment {
         waitlistLimitInput.setText("");
         hasWaitlistLimitCheckBox.setChecked(true);
         geolocationRequiredCheckBox.setChecked(false);
+        selectedImageUri = null;
+        posterImageView.setImageResource(R.drawable.ic_image_placeholder);
+        posterImageView.setBackgroundResource(R.drawable.poster_placeholder_bg);
+        createButton.setEnabled(true);
     }
 }

--- a/app/src/main/res/drawable/ic_image_placeholder.xml
+++ b/app/src/main/res/drawable/ic_image_placeholder.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="72dp"
+    android:height="72dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Image frame -->
+    <path
+        android:fillColor="@color/color_border"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14C20.1,21 21,20.1 21,19zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5L8.5,13.5z" />
+
+</vector>

--- a/app/src/main/res/drawable/poster_placeholder_bg.xml
+++ b/app/src/main/res/drawable/poster_placeholder_bg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/color_placeholder_bg" />
+    <stroke
+        android:width="1.5dp"
+        android:color="@color/color_border" />
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/layout/activity_profile_setup.xml
+++ b/app/src/main/res/layout/activity_profile_setup.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#FFFEF7FF">
+    android:background="#FFFFFFFF">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -18,7 +18,7 @@
             android:text="Set Up Your Profile"
             android:textSize="28sp"
             android:textStyle="bold"
-            android:textColor="#FF6200EE"
+            android:textColor="@color/color_primary"
             android:layout_marginTop="40dp"
             android:layout_marginBottom="8dp"/>
 
@@ -28,7 +28,7 @@
             android:layout_height="wrap_content"
             android:text="Tell us a bit about yourself to get started."
             android:textSize="15sp"
-            android:textColor="#666666"
+            android:textColor="@color/color_text_medium"
             android:layout_marginBottom="32dp"/>
 
         <!-- Name Field -->
@@ -37,7 +37,7 @@
             android:layout_height="wrap_content"
             android:text="Full Name *"
             android:textSize="14sp"
-            android:textColor="#333333"
+            android:textColor="@color/color_text_dark"
             android:textStyle="bold"
             android:layout_marginBottom="6dp"/>
 
@@ -57,7 +57,7 @@
             android:layout_height="wrap_content"
             android:text="Email Address *"
             android:textSize="14sp"
-            android:textColor="#333333"
+            android:textColor="@color/color_text_dark"
             android:textStyle="bold"
             android:layout_marginBottom="6dp"/>
 
@@ -77,7 +77,7 @@
             android:layout_height="wrap_content"
             android:text="Phone Number (optional)"
             android:textSize="14sp"
-            android:textColor="#333333"
+            android:textColor="@color/color_text_dark"
             android:textStyle="bold"
             android:layout_marginBottom="6dp"/>
 
@@ -99,7 +99,7 @@
             android:text="Save Profile"
             android:textSize="16sp"
             android:textColor="#FFFFFF"
-            android:backgroundTint="#FF6200EE"
+            android:backgroundTint="@color/color_primary"
             android:layout_marginBottom="16dp"/>
 
         <!-- Admin Login Link -->
@@ -109,7 +109,7 @@
             android:layout_height="wrap_content"
             android:text="Admin? Login here"
             android:textSize="14sp"
-            android:textColor="#FF6200EE"
+            android:textColor="@color/color_primary"
             android:textStyle="bold"
             android:layout_gravity="center"
             android:padding="12dp"

--- a/app/src/main/res/layout/fragment_create_event.xml
+++ b/app/src/main/res/layout/fragment_create_event.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="#FFFFFFFF">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -9,46 +10,121 @@
         android:orientation="vertical"
         android:padding="24dp">
 
+        <!-- Title -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Create Event"
+            android:textSize="28sp"
+            android:textStyle="bold"
+            android:textColor="@color/color_primary"
+            android:layout_marginTop="24dp"
+            android:layout_marginBottom="24dp"/>
+
+        <!-- Poster Section -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Event Poster"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:textColor="@color/color_text_dark"
+            android:layout_marginBottom="10dp"/>
+
+        <ImageView
+            android:id="@+id/image_event_poster"
+            android:layout_width="match_parent"
+            android:layout_height="360dp"
+            android:background="@drawable/poster_placeholder_bg"
+            android:src="@drawable/ic_image_placeholder"
+            android:scaleType="centerCrop"
+            android:clipToOutline="true"
+            android:contentDescription="Event poster preview"
+            android:layout_marginBottom="12dp" />
+
+        <Button
+            android:id="@+id/button_upload_poster"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:text="Upload Poster"
+            android:textColor="#FFFFFF"
+            android:backgroundTint="@color/color_primary"
+            android:layout_marginBottom="24dp"/>
+
+        <!-- Event Title -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Event Title"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:textColor="@color/color_text_dark"
+            android:layout_marginBottom="6dp"/>
+
         <EditText
             android:id="@+id/edit_event_title"
             android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:hint="Enter event title"
+            android:padding="12dp"
+            android:background="@drawable/rounded_input"
+            android:layout_marginBottom="20dp"/>
+
+        <!-- Description -->
+        <TextView
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:hint="Event title" />
+            android:text="Description"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:textColor="@color/color_text_dark"
+            android:layout_marginBottom="6dp"/>
 
         <EditText
             android:id="@+id/edit_event_description"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:hint="Description" />
+            android:layout_height="120dp"
+            android:hint="Describe your event"
+            android:padding="12dp"
+            android:background="@drawable/rounded_input"
+            android:gravity="top"
+            android:layout_marginBottom="24dp"/>
 
-        <EditText
-            android:id="@+id/edit_waitlist_limit"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:hint="Waitlist limit"
-            android:inputType="number" />
-
+        <!-- Waitlist -->
         <CheckBox
             android:id="@+id/checkbox_has_waitlist_limit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="Has waitlist limit"
-            android:checked="true" />
+            android:text="Limit waitlist size"
+            android:layout_marginBottom="8dp"/>
 
+        <EditText
+            android:id="@+id/edit_waitlist_limit"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:hint="Maximum waitlist size"
+            android:inputType="number"
+            android:background="@drawable/rounded_input"
+            android:padding="12dp"
+            android:layout_marginBottom="20dp"/>
+
+        <!-- Geolocation -->
         <CheckBox
             android:id="@+id/checkbox_geolocation_required"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Require geolocation" />
+            android:text="Require geolocation check"
+            android:layout_marginBottom="28dp"/>
 
+        <!-- Create Button -->
         <Button
             android:id="@+id/button_create_event"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:text="Create Event" />
+            android:layout_height="56dp"
+            android:text="Create Event"
+            android:textColor="#FFFFFF"
+            android:textSize="16sp"
+            android:backgroundTint="@color/color_primary"/>
+
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,4 +2,18 @@
 <resources>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <!-- Brand colors -->
+    <color name="color_primary">#9C27B0</color>
+    <color name="color_on_primary">#FFFFFF</color>
+    <color name="color_background">#FFFFFF</color>
+
+    <!-- Text colors -->
+    <color name="color_text_dark">#333333</color>
+    <color name="color_text_medium">#666666</color>
+    <color name="color_hint">#999999</color>
+
+    <!-- UI colors -->
+    <color name="color_border">#CCCCCC</color>
+    <color name="color_placeholder_bg">#EEEEEE</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,8 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
     <style name="Base.Theme.EventLotteryApp" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your light theme here. -->
-        <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
+        <item name="colorPrimary">@color/color_primary</item>
+        <item name="colorOnPrimary">@color/color_on_primary</item>
+        <item name="android:colorBackground">@color/color_background</item>
     </style>
 
     <style name="Theme.EventLotteryApp" parent="Base.Theme.EventLotteryApp" />


### PR DESCRIPTION
 **Closes #25 · US 02.04.01 - Organizer Event Poster Upload**

  - Organizers can now upload a poster image when creating an event via the gallery picker
  - Images are compressed before upload (scaled to max 1024px longest side, JPEG 80%) using `BitmapFactory.decodeStream` to minimize Firebase Storage usage
  - Uploaded poster URL is stored in the event's existing `posterUrl` field in Firestore via Firebase Storage
  - Added `ImageRepository` to handle all image compression and Firebase Storage upload logic

 **UI changes**
  - Create event form now shows a portrait-style `ImageView `with a grey placeholder and image icon before a poster is selected
  - Selected image replaces the placeholder and is clipped to the rounded rectangle frame
  - Defined named color resources in `colors.xml` and set `colorPrimary` in theme so the magenta color is consistent across screens without hardcoded hex values
  
<img width="437" height="908" alt="image" src="https://github.com/user-attachments/assets/1e4aa2bb-a7e3-4604-955b-0e40f20ae050" />

<img width="422" height="895" alt="image" src="https://github.com/user-attachments/assets/22c8c6e8-b1ac-4842-bcfb-ab8b629a309f" />

